### PR TITLE
試験的に２つのSlackTokenを設定できるように

### DIFF
--- a/src/components/StreamNotify.tsx
+++ b/src/components/StreamNotify.tsx
@@ -36,6 +36,9 @@ export default class StreamNotify extends Component<Props, State> {
         </div>
         <div className="StreamNotify__main">
           <div className="StreamNotify__main__meta">
+            <span className="StreamNotify__main__meta__team">
+              {letter.team.name}
+            </span>
             <span className="StreamNotify__main__meta__user">
               {letter.user.name}
             </span>

--- a/src/components/TypingNotify.tsx
+++ b/src/components/TypingNotify.tsx
@@ -45,8 +45,9 @@ export default class TypingNotify extends Component<Props, State> {
           <div className="TypingNotify__meta__image">
             <img src={letter.user.image} />
           </div>
-          <div className="TypingNotify__meta__user">
-            {letter.user.name}
+          <div className="TypingNotify__meta__teamuser">
+            <span className="team">{letter.team.name}</span>
+            <span className="user">{letter.user.name}</span>
           </div>
           <div className="TypingNotify__meta__channel">
             {letter.channel.name}

--- a/src/containers/MainContainer.tsx
+++ b/src/containers/MainContainer.tsx
@@ -45,7 +45,6 @@ class MainContainer extends Component<Props, any> {
       connectSlack(setting.slackToken)
     }
     if (setting.slackTokenAlt) {
-      console.log(setting.slackTokenAlt)
       connectSlack(setting.slackTokenAlt)
     }
     this.setTimeoutAutoReload()

--- a/src/containers/MainContainer.tsx
+++ b/src/containers/MainContainer.tsx
@@ -41,8 +41,12 @@ class MainContainer extends Component<Props, any> {
       location.hash = `/${setting.notifyType}`
     }
     const {connectSlack} = this.props.postAction
-    if (connectSlack) {
+    if (setting.slackToken) {
       connectSlack(setting.slackToken)
+    }
+    if (setting.slackTokenAlt) {
+      console.log(setting.slackTokenAlt)
+      connectSlack(setting.slackTokenAlt)
     }
     this.setTimeoutAutoReload()
   }

--- a/src/containers/SettingContainer.tsx
+++ b/src/containers/SettingContainer.tsx
@@ -36,6 +36,15 @@ class SettingContainer extends Component<Props, any> {
             <Button onClick={() => this.openOAuth()}>OAuth</Button>
           </div>
           <div className="pure-control-group">
+            <label>Slack Token Alt</label>
+            <TextField
+              placeholder="Slack Token"
+              value={setting.slackTokenAlt}
+              hideFirst={true}
+              onChange={slackTokenAlt => this.changeValue({slackTokenAlt})} />
+            <Button onClick={() => this.openOAuthAlt()}>OAuth</Button>
+          </div>
+          <div className="pure-control-group">
             <label>Remove Msec</label>
             <TextField
               placeholder="Remove Msec"
@@ -64,18 +73,30 @@ class SettingContainer extends Component<Props, any> {
 
   private changeValue(obj: any) {
     const {setting} = this.props
-    this.props.action.updateSetting(
-      new Setting({
-        slackToken: obj.slackToken || setting.slackToken,
-        notifyType: obj.notifyType || setting.notifyType,
-        removeMsec: obj.removeMsec || setting.removeMsec,
-      })
-    )
+    if (obj.slackToken === undefined) {
+      obj.slackToken = setting.slackToken
+    }
+    if (obj.slackTokenAlt === undefined) {
+      obj.slackTokenAlt = setting.slackTokenAlt
+    }
+    if (obj.notifyType === undefined) {
+      obj.notifyType = setting.notifyType
+    }
+    if (obj.removeMsec === undefined) {
+      obj.removeMsec = setting.removeMsec
+    }
+    this.props.action.updateSetting(new Setting(obj))
   }
 
   private openOAuth() {
     GlobalRepository.settingWindow.openOAuth()
     .then(slackToken => this.changeValue({slackToken}))
+    .catch(err => alert("Error"))
+  }
+
+  private openOAuthAlt() {
+    GlobalRepository.settingWindow.openOAuth()
+    .then(slackTokenAlt => this.changeValue({slackTokenAlt}))
     .catch(err => alert("Error"))
   }
 }

--- a/src/domains/Letter.ts
+++ b/src/domains/Letter.ts
@@ -1,5 +1,6 @@
 /// <reference path="../reference.d.ts" />
 import UniqueID from "./UniqueID"
+import Team from "./Team"
 import User from "./User"
 import Channel from "./Channel"
 import Message from "./Message"
@@ -9,6 +10,7 @@ import freeze from "../decorators/freeze"
 export default class Letter {
 
   constructor(private param: {
+    team: Team,
     user: User,
     channel: Channel,
     message: Message,
@@ -21,6 +23,10 @@ export default class Letter {
 
   get id(): string {
     return this.param.uid.toString()
+  }
+
+  get team(): Team {
+    return this.param.team
   }
 
   get user(): User {

--- a/src/domains/Setting.ts
+++ b/src/domains/Setting.ts
@@ -6,12 +6,17 @@ export default class Setting {
 
   constructor(private param: {
     slackToken: string,
+    slackTokenAlt: string,
     notifyType: string,
     removeMsec: number,
   }) {}
 
   get slackToken(): string {
     return this.param.slackToken
+  }
+
+  get slackTokenAlt(): string {
+    return this.param.slackTokenAlt
   }
 
   get notifyType(): string {

--- a/src/domains/SlackObject.ts
+++ b/src/domains/SlackObject.ts
@@ -1,4 +1,13 @@
 /// <reference path="../reference.d.ts" />
+
+export interface TeamObject {
+  team: {
+    id: string,
+    name: string,
+    domain: string,
+  }
+}
+
 export interface UserObject {
   id: string
   name: string

--- a/src/domains/Team.ts
+++ b/src/domains/Team.ts
@@ -1,0 +1,24 @@
+/// <reference path="../reference.d.ts" />
+import freeze from "../decorators/freeze"
+
+@freeze
+export default class Team {
+
+  constructor(private param: {
+    id: string
+    name: string,
+    domain: string,
+  }) {}
+
+  get id(): string {
+    return this.param.id
+  }
+
+  get name(): string {
+    return this.param.name
+  }
+
+  get domain(): string {
+    return this.param.domain
+  }
+}

--- a/src/reducers/setting.ts
+++ b/src/reducers/setting.ts
@@ -14,6 +14,7 @@ import GlobalRepository from "../domains/GlobalRepository"
 
 const initialState: Setting = new Setting({
   slackToken: localStorage["slackToken"] || "",
+  slackTokenAlt: localStorage["slackTokenAlt"] || "",
   notifyType: localStorage["notifyType"] || DEFAULT_NOTIFY_TYPE,
   removeMsec: localStorage["removeMsec"] || DEFAULT_REMOVE_MSEC,
 })
@@ -31,6 +32,7 @@ export default function setting(
     break
   case SAVE_SETTING:
     localStorage["slackToken"] = state.slackToken
+    localStorage["slackTokenAlt"] = state.slackTokenAlt
     localStorage["notifyType"] = state.notifyType
     localStorage["removeMsec"] = state.removeMsec
     GlobalRepository.mainWindow.reload()

--- a/src/styles/components/StreamNotify.styl
+++ b/src/styles/components/StreamNotify.styl
@@ -31,6 +31,8 @@
         -1px 1px 1px #000,
         1px -1px 1px #000,
         -1px -1px 1px #000
+      &__team
+        margin-right 1em
       &__user
         margin-right 1em
         &:before

--- a/src/styles/components/TypingNotify.styl
+++ b/src/styles/components/TypingNotify.styl
@@ -23,9 +23,13 @@
           -1px 1px 0px rgba(0,0,0,0.2),
           1px -1px 0px rgba(0,0,0,0.2),
           -1px -1px 0px rgba(0,0,0,0.2)
-    &__user
-      &:before
-        content '@'
+    &__teamuser
+      .team
+        margin-right 0.5em
+      .user
+        &:before
+          content '@'
+          color #f33
     &__channel
       &:before
         color #3f3

--- a/src/windows/SettingWindow.ts
+++ b/src/windows/SettingWindow.ts
@@ -45,7 +45,7 @@ export default class SettingWindow {
   private constructor() {
     this.window = new BrowserWindow({
       width: 600,
-      height: 240,
+      height: 280,
       center: true,
       frame: false,
       resizable: false,

--- a/test/domains/Letter.spec.ts
+++ b/test/domains/Letter.spec.ts
@@ -1,4 +1,5 @@
 import Letter from 'domains/Letter'
+import Team from 'domains/Team'
 import User from 'domains/User'
 import Channel from 'domains/Channel'
 import Message from 'domains/Message'
@@ -7,11 +8,17 @@ import * as assert from 'power-assert'
 describe('Letter', function() {
 
   let letter: Letter
+  let team: Team
   let user: User
   let channel: Channel
   let message: Message
 
   before(() => {
+    team = new Team({
+      id: 'ID',
+      name: 'Team',
+      domain: 'Domain',
+    })
     user = new User({
       id: 'ID',
       name: 'User',
@@ -22,7 +29,7 @@ describe('Letter', function() {
     })
     message = new Message('Text')
     letter = new Letter({
-      user, channel, message,
+      team, user, channel, message,
     })
   })
 
@@ -36,6 +43,12 @@ describe('Letter', function() {
     it('should be return identify string', () => {
       assert(typeof letter.id === 'string')
       assert(letter.id.length > 0)
+    })
+  })
+
+  describe('team', () => {
+    it('should be return initial value', () => {
+      assert(letter.team === team)
     })
   })
 

--- a/test/domains/Post.spec.ts
+++ b/test/domains/Post.spec.ts
@@ -1,5 +1,6 @@
 import Post from 'domains/Post'
 import Letter from 'domains/Letter'
+import Team from 'domains/Team'
 import User from 'domains/User'
 import Channel from 'domains/Channel'
 import Message from 'domains/Message'
@@ -13,6 +14,11 @@ describe('Letter', function() {
   let letters: Array<Letter>
 
   before(() => {
+    const team = new Team({
+      id: 'ID',
+      name: 'Team',
+      domain: 'Domain',
+    })
     const user = new User({
       id: 'ID',
       name: 'User',
@@ -22,8 +28,8 @@ describe('Letter', function() {
       name: 'Channel',
     })
     const message = new Message('Text')
-    letter1 = new Letter({user, channel, message})
-    letter2 = new Letter({user, channel, message})
+    letter1 = new Letter({team, user, channel, message})
+    letter2 = new Letter({team, user, channel, message})
     letters = [letter1, letter2]
     post = new Post({letters})
   })

--- a/test/domains/Setting.spec.ts
+++ b/test/domains/Setting.spec.ts
@@ -8,6 +8,7 @@ describe('Setting', function() {
   before(() => {
     setting = new Setting({
       slackToken: 'SlackToken',
+      slackTokenAlt: 'SlackTokenAlt',
       notifyType: 'NotifyType',
       removeMsec: 1234,
     })
@@ -22,6 +23,12 @@ describe('Setting', function() {
   describe('slackToken', () => {
     it('should be return initial value', () => {
       assert(setting.slackToken === 'SlackToken')
+    })
+  })
+
+  describe('slackTokenAlt', () => {
+    it('should be return initial value', () => {
+      assert(setting.slackTokenAlt === 'SlackTokenAlt')
     })
   })
 

--- a/test/domains/Team.spec.ts
+++ b/test/domains/Team.spec.ts
@@ -1,0 +1,39 @@
+import Team from 'domains/Team'
+import * as assert from 'power-assert'
+
+describe('Team', function() {
+
+  let team: Team
+
+  before(() => {
+    team = new Team({
+      id: 'ID',
+      name: 'Name',
+      domain: 'Domain',
+    })
+  })
+
+  describe('new', () => {
+    it('should be return new instance', () => {
+      assert(team instanceof Team)
+    })
+  })
+
+  describe('id', () => {
+    it('should be return initial value', () => {
+      assert(team.id === 'ID')
+    })
+  })
+
+  describe('name', () => {
+    it('should be return initial value', () => {
+      assert(team.name === 'Name')
+    })
+  })
+
+  describe('domain', () => {
+    it('should be return initial value', () => {
+      assert(team.domain === 'Domain')
+    })
+  })
+})


### PR DESCRIPTION
眠れぬ夜のPR 第二弾。
- 複数のチームの通知を受け取れるかを試験的に確かめるために設定項目を追加
- どちらのチームか識別できるように、通知表示にチーム名を追加
